### PR TITLE
Fix parameter types in subscribe messages

### DIFF
--- a/packages/moqt-transport/src/message/subscribe.rs
+++ b/packages/moqt-transport/src/message/subscribe.rs
@@ -1,7 +1,7 @@
 use bytes::{BufMut, BytesMut};
 use tokio_util::codec::{Decoder, Encoder};
 
-use crate::model::{Location, SetupParameter};
+use crate::model::{Location, Parameter};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Subscribe {
@@ -14,7 +14,7 @@ pub struct Subscribe {
     pub filter_type: u64,
     pub start_location: Option<Location>,
     pub end_group: Option<u64>,
-    pub parameters: Vec<SetupParameter>,
+    pub parameters: Vec<Parameter>,
 }
 
 impl Subscribe {
@@ -124,7 +124,7 @@ impl Subscribe {
                 return Err(IoError::new(ErrorKind::UnexpectedEof, "parameter value").into());
             }
             let value = buf.split_to(len).to_vec();
-            parameters.push(SetupParameter { parameter_type: ty, value });
+            parameters.push(Parameter { parameter_type: ty, value });
         }
 
         Ok(Subscribe {
@@ -158,7 +158,7 @@ mod tests {
             filter_type: 0x4,
             start_location: Some(Location { group: 10, object: 5 }),
             end_group: Some(20),
-            parameters: vec![SetupParameter { parameter_type: 1, value: vec![42] }],
+            parameters: vec![Parameter { parameter_type: 1, value: vec![42] }],
         };
 
         let mut buf = BytesMut::new();

--- a/packages/moqt-transport/src/message/subscribe_ok.rs
+++ b/packages/moqt-transport/src/message/subscribe_ok.rs
@@ -1,7 +1,7 @@
 use bytes::{BufMut, BytesMut};
 use tokio_util::codec::{Decoder, Encoder};
 
-use crate::model::{Location, SetupParameter};
+use crate::model::{Location, Parameter};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct SubscribeOk {
@@ -11,7 +11,7 @@ pub struct SubscribeOk {
     pub group_order: u8,
     pub content_exists: bool,
     pub largest_location: Option<Location>,
-    pub parameters: Vec<SetupParameter>,
+    pub parameters: Vec<Parameter>,
 }
 
 impl SubscribeOk {
@@ -95,7 +95,7 @@ impl SubscribeOk {
                 return Err(IoError::new(ErrorKind::UnexpectedEof, "parameter value").into());
             }
             let value = buf.split_to(len).to_vec();
-            parameters.push(SetupParameter { parameter_type: ty, value });
+            parameters.push(Parameter { parameter_type: ty, value });
         }
 
         Ok(SubscribeOk {
@@ -123,7 +123,7 @@ mod tests {
             group_order: 1,
             content_exists: true,
             largest_location: Some(Location { group: 10, object: 7 }),
-            parameters: vec![SetupParameter { parameter_type: 1, value: vec![42] }],
+            parameters: vec![Parameter { parameter_type: 1, value: vec![42] }],
         };
 
         let mut buf = BytesMut::new();

--- a/packages/moqt-transport/src/model.rs
+++ b/packages/moqt-transport/src/model.rs
@@ -7,6 +7,12 @@ pub struct SetupParameter {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Parameter {
+    pub parameter_type: u64,
+    pub value: Vec<u8>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Location {
     pub group: u64,
     pub object: u64,


### PR DESCRIPTION
## Summary
- add a dedicated `Parameter` struct for version-specific parameters
- use `Parameter` instead of `SetupParameter` in `Subscribe` and `SubscribeOk`

## Testing
- `cargo test -p moqt-transport`

------
https://chatgpt.com/codex/tasks/task_e_685d8fea7ebc8329b339a2342e18f185