### PR TITLE
Implement AnnounceOk encode/decode

### DIFF
--- a/packages/moqt-transport/src/message/announce_ok.rs
+++ b/packages/moqt-transport/src/message/announce_ok.rs
@@ -1,12 +1,55 @@
 use bytes::BytesMut;
-pub struct AnnounceOk {}
+use tokio_util::codec::{Decoder, Encoder};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct AnnounceOk {
+    pub request_id: u64,
+}
 
 impl AnnounceOk {
-    pub fn encode(&self, _buf: &mut BytesMut) -> Result<(), crate::error::Error> {
-        todo!()
+    pub fn encode(&self, buf: &mut BytesMut) -> Result<(), crate::error::Error> {
+        let mut vi = crate::codec::VarInt;
+        vi.encode(self.request_id, buf)?;
+        Ok(())
     }
 
-    pub fn decode(_buf: &mut BytesMut) -> Result<Self, crate::error::Error> {
-        todo!()
+    pub fn decode(buf: &mut BytesMut) -> Result<Self, crate::error::Error> {
+        use std::io::{Error as IoError, ErrorKind};
+
+        let mut vi = crate::codec::VarInt;
+        let request_id = vi
+            .decode(buf)?
+            .ok_or_else(|| IoError::new(ErrorKind::UnexpectedEof, "request id"))?;
+
+        Ok(AnnounceOk { request_id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let msg = AnnounceOk { request_id: 42 };
+
+        let mut buf = BytesMut::new();
+        msg.encode(&mut buf).unwrap();
+
+        let mut decode_buf = buf.clone();
+        let decoded = AnnounceOk::decode(&mut decode_buf).unwrap();
+        assert!(decode_buf.is_empty());
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn decode_incomplete() {
+        let mut buf = BytesMut::new();
+        match AnnounceOk::decode(&mut buf) {
+            Err(crate::error::Error::Io(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof);
+            }
+            r => panic!("unexpected result: {:?}", r),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement encode/decode for `AnnounceOk` message in `moqt-transport`
- add unit tests for AnnounceOk

## Testing
- `cargo test -p moqt-transport`

------
https://chatgpt.com/codex/tasks/task_e_685dfa9cc97083298ba7f7e2686f47d4