### PR TITLE
Implement SubscribeAnnouncesOk message

### DIFF
--- a/packages/moqt-transport/src/message/subscribe_announces_ok.rs
+++ b/packages/moqt-transport/src/message/subscribe_announces_ok.rs
@@ -1,12 +1,55 @@
 use bytes::BytesMut;
-pub struct SubscribeAnnouncesOk {}
+use tokio_util::codec::{Decoder, Encoder};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct SubscribeAnnouncesOk {
+    pub request_id: u64,
+}
 
 impl SubscribeAnnouncesOk {
-    pub fn encode(&self, _buf: &mut BytesMut) -> Result<(), crate::error::Error> {
-        todo!()
+    pub fn encode(&self, buf: &mut BytesMut) -> Result<(), crate::error::Error> {
+        let mut vi = crate::codec::VarInt;
+        vi.encode(self.request_id, buf)?;
+        Ok(())
     }
 
-    pub fn decode(_buf: &mut BytesMut) -> Result<Self, crate::error::Error> {
-        todo!()
+    pub fn decode(buf: &mut BytesMut) -> Result<Self, crate::error::Error> {
+        use std::io::{Error as IoError, ErrorKind};
+
+        let mut vi = crate::codec::VarInt;
+        let request_id = vi
+            .decode(buf)?
+            .ok_or_else(|| IoError::new(ErrorKind::UnexpectedEof, "request id"))?;
+
+        Ok(SubscribeAnnouncesOk { request_id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let msg = SubscribeAnnouncesOk { request_id: 99 };
+
+        let mut buf = BytesMut::new();
+        msg.encode(&mut buf).unwrap();
+
+        let mut decode_buf = buf.clone();
+        let decoded = SubscribeAnnouncesOk::decode(&mut decode_buf).unwrap();
+        assert!(decode_buf.is_empty());
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn decode_incomplete() {
+        let mut buf = BytesMut::new();
+        match SubscribeAnnouncesOk::decode(&mut buf) {
+            Err(crate::error::Error::Io(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof);
+            }
+            r => panic!("unexpected result: {:?}", r),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement encode/decode for `SubscribeAnnouncesOk`
- add round-trip and error unit tests

## Testing
- `cargo test -p moqt-transport -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_685dfbec74188329a80ced67dd98fd4f