### PR TITLE
Add validation for control message fields

### DIFF
--- a/packages/moqt-transport/src/message/fetch.rs
+++ b/packages/moqt-transport/src/message/fetch.rs
@@ -26,6 +26,9 @@ impl Fetch {
 
         vi.encode(self.request_id, buf)?;
         buf.put_u8(self.subscriber_priority);
+        if self.group_order > 2 {
+            return Err(IoError::new(ErrorKind::InvalidData, "invalid group order").into());
+        }
         buf.put_u8(self.group_order);
         vi.encode(self.fetch_type, buf)?;
 
@@ -92,6 +95,9 @@ impl Fetch {
         }
         let subscriber_priority = buf.split_to(1)[0];
         let group_order = buf.split_to(1)[0];
+        if group_order > 2 {
+            return Err(IoError::new(ErrorKind::InvalidData, "invalid group order").into());
+        }
 
         let fetch_type = vi
             .decode(buf)?

--- a/packages/moqt-transport/src/message/publish.rs
+++ b/packages/moqt-transport/src/message/publish.rs
@@ -30,7 +30,14 @@ impl Publish {
 
         vi.encode(self.track_alias, buf)?;
 
+        if self.group_order == 0 || self.group_order > 2 {
+            return Err(IoError::new(ErrorKind::InvalidData, "invalid group order").into());
+        }
         buf.put_u8(self.group_order);
+
+        if self.content_exists != 0 && self.content_exists != 1 {
+            return Err(IoError::new(ErrorKind::InvalidData, "invalid content exists value").into());
+        }
         buf.put_u8(self.content_exists);
 
         if self.content_exists == 1 {
@@ -85,7 +92,13 @@ impl Publish {
             return Err(IoError::new(ErrorKind::UnexpectedEof, "flags").into());
         }
         let group_order = buf.split_to(1)[0];
+        if group_order == 0 || group_order > 2 {
+            return Err(IoError::new(ErrorKind::InvalidData, "invalid group order").into());
+        }
         let content_exists = buf.split_to(1)[0];
+        if content_exists != 0 && content_exists != 1 {
+            return Err(IoError::new(ErrorKind::InvalidData, "invalid content exists value").into());
+        }
 
         let largest = if content_exists == 1 {
             Some(Location::decode(buf)?)
@@ -97,6 +110,9 @@ impl Publish {
             return Err(IoError::new(ErrorKind::UnexpectedEof, "forward").into());
         }
         let forward = buf.split_to(1)[0];
+        if forward != 0 && forward != 1 {
+            return Err(IoError::new(ErrorKind::InvalidData, "invalid forward value").into());
+        }
 
         let params_len = vi
             .decode(buf)?
@@ -164,7 +180,7 @@ mod tests {
             track_namespace: 7,
             track_name: "audio".into(),
             track_alias: 8,
-            group_order: 0,
+            group_order: 1,
             content_exists: 0,
             largest: None,
             forward: 0,

--- a/packages/moqt-transport/src/message/subscribe_ok.rs
+++ b/packages/moqt-transport/src/message/subscribe_ok.rs
@@ -22,6 +22,13 @@ impl SubscribeOk {
         vi.encode(self.track_alias, buf)?;
         vi.encode(self.expires, buf)?;
 
+        if self.group_order == 0 || self.group_order > 2 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "invalid group order",
+            )
+            .into());
+        }
         buf.put_u8(self.group_order);
         buf.put_u8(if self.content_exists { 1 } else { 0 });
 
@@ -62,6 +69,9 @@ impl SubscribeOk {
             return Err(IoError::new(ErrorKind::UnexpectedEof, "flags").into());
         }
         let group_order = buf.split_to(1)[0];
+        if group_order == 0 || group_order > 2 {
+            return Err(IoError::new(ErrorKind::InvalidData, "invalid group order").into());
+        }
         let content_exists_byte = buf.split_to(1)[0];
         let content_exists = match content_exists_byte {
             0 => false,

--- a/packages/moqt-transport/src/message/subscribe_update.rs
+++ b/packages/moqt-transport/src/message/subscribe_update.rs
@@ -22,6 +22,9 @@ impl SubscribeUpdate {
         vi.encode(self.end_group, buf)?;
 
         buf.put_u8(self.subscriber_priority);
+        if self.forward != 0 && self.forward != 1 {
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid forward value").into());
+        }
         buf.put_u8(self.forward);
 
         vi.encode(self.parameters.len() as u64, buf)?;


### PR DESCRIPTION
## Summary
- enforce spec limits for Subscribe forward/group order/filter types
- enforce valid values in Publish and PublishOk messages
- check group order in Fetch messages
- guard forward in SubscribeUpdate
- update unit tests for stricter validation

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685e0077896483298d8772d31e1f3945