### PR TITLE
Add session and transport scaffolding

### DIFF
--- a/packages/moqt-transport/src/coding.rs
+++ b/packages/moqt-transport/src/coding.rs
@@ -13,9 +13,12 @@ use crate::{
     },
 };
 
-pub struct Codec;
+/// `MoqCodec` encodes and decodes [`ControlMessage`] frames on the control
+/// stream. It uses the variable-length integer utilities provided in this
+/// module.
+pub struct MoqCodec;
 
-impl Encoder<ControlMessage> for Codec {
+impl Encoder<ControlMessage> for MoqCodec {
     type Error = Error;
 
     fn encode(&mut self, item: ControlMessage, dst: &mut BytesMut) -> Result<(), Self::Error> {
@@ -228,7 +231,7 @@ impl Encoder<ControlMessage> for Codec {
     }
 }
 
-impl Decoder for Codec {
+impl Decoder for MoqCodec {
     type Item = ControlMessage;
     type Error = Error;
 

--- a/packages/moqt-transport/src/error.rs
+++ b/packages/moqt-transport/src/error.rs
@@ -1,9 +1,29 @@
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("std::io::Error")]
-    Io(#[from] std::io::Error),
+    #[error("Transport layer error: {0}")]
+    Transport(Box<dyn std::error::Error + Send + Sync>),
+
+    #[error("Failed to decode message: {0}")]
+    Codec(String),
+
+    #[error("Protocol violation: {reason}")]
+    ProtocolViolation { reason: String },
+
+    #[error("Subscription failed: {reason}")]
+    SubscriptionFailed { code: u64, reason: String },
+
+    #[error("Session closed")]
+    SessionClosed,
+
+    #[error("Invalid track alias: {0}")]
+    DuplicateTrackAlias(u64),
+
     #[error("varint out of range")]
     VarIntRange,
+
     #[error("unknown message type")]
     UnknownMessageType,
+
+    #[error("std::io::Error")]
+    Io(#[from] std::io::Error),
 }

--- a/packages/moqt-transport/src/lib.rs
+++ b/packages/moqt-transport/src/lib.rs
@@ -1,4 +1,14 @@
-pub mod codec;
+pub mod coding;
+/// Temporary re-export for compatibility with older module name.
+pub mod codec {
+    pub use super::coding::*;
+}
 pub mod error;
 pub mod message;
 pub mod model;
+pub mod session;
+pub mod track;
+pub mod transport;
+
+pub use session::Session;
+pub use track::{Object, ObjectMetadata, TrackManager};

--- a/packages/moqt-transport/src/session.rs
+++ b/packages/moqt-transport/src/session.rs
@@ -1,0 +1,41 @@
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+
+use crate::{
+    message::ControlMessage,
+    transport::Transport,
+    track::TrackManager,
+};
+
+pub enum State {
+    Initializing,
+    Active,
+    Closing,
+}
+
+pub struct Session<T: Transport> {
+    state: Arc<Mutex<State>>,
+    pub(crate) control_tx: mpsc::Sender<ControlMessage>,
+    pub track_manager: TrackManager,
+    pub transport: Arc<T>,
+}
+
+impl<T: Transport> Session<T> {
+    pub fn new(transport: Arc<T>) -> (Self, mpsc::Receiver<ControlMessage>) {
+        let (tx, rx) = mpsc::channel(16);
+        let session = Session {
+            state: Arc::new(Mutex::new(State::Initializing)),
+            control_tx: tx,
+            track_manager: TrackManager::default(),
+            transport,
+        };
+        (session, rx)
+    }
+
+    pub async fn send_control(&self, msg: ControlMessage) -> Result<(), crate::error::Error> {
+        self.control_tx
+            .send(msg)
+            .await
+            .map_err(|e| crate::error::Error::Transport(Box::new(e)))
+    }
+}

--- a/packages/moqt-transport/src/track.rs
+++ b/packages/moqt-transport/src/track.rs
@@ -1,0 +1,60 @@
+use bytes::Bytes;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use crate::error::Error;
+
+pub type FullTrackName = String;
+pub type TrackAlias = u64;
+
+#[derive(Default)]
+pub struct TrackManager {
+    tracks: RwLock<HashMap<FullTrackName, Arc<TrackState>>>,
+    aliases: RwLock<HashMap<TrackAlias, FullTrackName>>, 
+}
+
+struct TrackState {
+    name: FullTrackName,
+}
+
+impl TrackManager {
+    pub fn assign_alias(&self, alias: TrackAlias, name: FullTrackName) -> Result<(), Error> {
+        let mut aliases = self.aliases.write().unwrap();
+        if aliases.contains_key(&alias) {
+            return Err(Error::DuplicateTrackAlias(alias));
+        }
+        aliases.insert(alias, name);
+        Ok(())
+    }
+
+    pub fn resolve_alias(&self, alias: TrackAlias) -> Option<FullTrackName> {
+        let aliases = self.aliases.read().unwrap();
+        aliases.get(&alias).cloned()
+    }
+}
+
+pub struct Track {
+    pub name: FullTrackName,
+}
+
+pub struct TrackPublisher {
+    track_alias: TrackAlias,
+}
+
+impl TrackPublisher {
+    pub fn alias(&self) -> TrackAlias {
+        self.track_alias
+    }
+}
+
+pub struct Object {
+    pub metadata: ObjectMetadata,
+    pub payload: Bytes,
+}
+
+pub struct ObjectMetadata {
+    pub track_alias: u64,
+    pub group_id: u64,
+    pub object_id: u64,
+    pub priority: u8,
+}

--- a/packages/moqt-transport/src/transport.rs
+++ b/packages/moqt-transport/src/transport.rs
@@ -1,0 +1,26 @@
+use std::future::Future;
+use std::pin::Pin;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+pub trait UniStream: AsyncRead + AsyncWrite + Unpin + Send {}
+impl<T> UniStream for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
+
+pub trait BiStream: Send {
+    type Reader: AsyncRead + Unpin + Send;
+    type Writer: AsyncWrite + Unpin + Send;
+
+    fn split(self) -> (Self::Reader, Self::Writer);
+}
+
+pub trait Transport: Send + Sync {
+    type Uni: UniStream;
+    type Bi: BiStream;
+
+    fn open_uni_stream(&mut self) -> Pin<Box<dyn Future<Output = Result<Self::Uni, BoxError>> + Send>>;
+    fn accept_uni_stream(&mut self) -> Pin<Box<dyn Future<Output = Result<Self::Uni, BoxError>> + Send>>;
+
+    fn open_bi_stream(&mut self) -> Pin<Box<dyn Future<Output = Result<Self::Bi, BoxError>> + Send>>;
+    fn accept_bi_stream(&mut self) -> Pin<Box<dyn Future<Output = Result<Self::Bi, BoxError>> + Send>>;
+}


### PR DESCRIPTION
## Summary
- add initial session and track management modules
- define generic Transport trait
- rename codec module to `coding` and introduce `MoqCodec`
- expand error definitions
- expose new types from lib.rs

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_685e266f285c832989f2b577dfb3d0d4