### PR TITLE
Add missing CLIENT_SETUP/ SERVER_SETUP decode_incomplete tests

### DIFF
--- a/packages/moqt-transport/src/message/client_setup.rs
+++ b/packages/moqt-transport/src/message/client_setup.rs
@@ -131,4 +131,15 @@ mod tests {
         assert!(decode_buf.is_empty());
         assert_eq!(decoded, msg);
     }
+
+    #[test]
+    fn decode_incomplete() {
+        let mut buf = BytesMut::new();
+        match ClientSetup::decode(&mut buf) {
+            Err(crate::error::Error::Io(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof);
+            }
+            r => panic!("unexpected result: {:?}", r),
+        }
+    }
 }

--- a/packages/moqt-transport/src/message/server_setup.rs
+++ b/packages/moqt-transport/src/message/server_setup.rs
@@ -119,4 +119,15 @@ mod tests {
         assert!(decode_buf.is_empty());
         assert_eq!(decoded, msg);
     }
+
+    #[test]
+    fn decode_incomplete() {
+        let mut buf = BytesMut::new();
+        match ServerSetup::decode(&mut buf) {
+            Err(crate::error::Error::Io(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof);
+            }
+            r => panic!("unexpected result: {:?}", r),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add tests verifying CLIENT_SETUP decode returns UnexpectedEof on incomplete input
- add corresponding test for SERVER_SETUP

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_685e534ad3588329b3d61937621f23ef