### PR TITLE
Enforce GOAWAY URI length

### DIFF
--- a/packages/moqt-transport/src/message/goaway.rs
+++ b/packages/moqt-transport/src/message/goaway.rs
@@ -31,12 +31,18 @@ pub struct Goaway {
 }
 
 impl Goaway {
+    const MAX_URI_LENGTH: usize = 8_192;
+
     pub fn encode(&self, buf: &mut BytesMut) -> Result<(), crate::error::Error> {
         let mut vi = crate::coding::VarInt;
 
         // New Session URI
         if let Some(uri) = &self.new_session_uri {
             let bytes = uri.as_bytes();
+            if bytes.len() > Self::MAX_URI_LENGTH {
+                use std::io::{Error as IoError, ErrorKind};
+                return Err(IoError::new(ErrorKind::InvalidData, "uri too long").into());
+            }
             vi.encode(bytes.len() as u64, buf)?;
             buf.put_slice(bytes);
         } else {
@@ -56,6 +62,9 @@ impl Goaway {
             .decode(buf)?
             .ok_or_else(|| IoError::new(ErrorKind::UnexpectedEof, "uri length"))?
             as usize;
+        if len > Self::MAX_URI_LENGTH {
+            return Err(IoError::new(ErrorKind::InvalidData, "uri too long").into());
+        }
         if buf.len() < len {
             return Err(IoError::new(ErrorKind::UnexpectedEof, "uri").into());
         }
@@ -106,5 +115,25 @@ mod tests {
         let decoded = Goaway::decode(&mut decode_buf).unwrap();
         assert!(decode_buf.is_empty());
         assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn encode_fails_on_long_uri() {
+        let msg = Goaway {
+            new_session_uri: Some("a".repeat(Goaway::MAX_URI_LENGTH + 1)),
+        };
+
+        let mut buf = BytesMut::new();
+        assert!(msg.encode(&mut buf).is_err());
+    }
+
+    #[test]
+    fn decode_fails_on_long_uri() {
+        let mut buf = BytesMut::new();
+        let mut vi = crate::coding::VarInt;
+        vi.encode((Goaway::MAX_URI_LENGTH + 1) as u64, &mut buf).unwrap();
+        buf.extend(std::iter::repeat(b'a').take(Goaway::MAX_URI_LENGTH + 1));
+
+        assert!(Goaway::decode(&mut buf).is_err());
     }
 }


### PR DESCRIPTION
## Summary
- enforce the 8,192 byte limit for GOAWAY URI fields
- add tests for overlong GOAWAY URI payloads

## Testing
- `cargo test -p moqt-transport --lib --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685e536a0f6c8329918e881109822cc5