### PR TITLE
Add decode_incomplete test for REQUESTS_BLOCKED

### DIFF
--- a/packages/moqt-transport/src/message/requests_blocked.rs
+++ b/packages/moqt-transport/src/message/requests_blocked.rs
@@ -63,4 +63,15 @@ mod tests {
         assert!(decode_buf.is_empty());
         assert_eq!(decoded, msg);
     }
+
+    #[test]
+    fn decode_incomplete() {
+        let mut buf = BytesMut::new();
+        match RequestsBlocked::decode(&mut buf) {
+            Err(crate::error::Error::Io(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof);
+            }
+            r => panic!("unexpected result: {:?}", r),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- ensure REQUESTS_BLOCKED decoding handles incomplete buffers

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685e5389e1a88329bc6e08b27e7a48d1