### PR TITLE
Add test for SERVER_SETUP with no parameters

### DIFF
--- a/packages/moqt-transport/src/message/server_setup.rs
+++ b/packages/moqt-transport/src/message/server_setup.rs
@@ -121,6 +121,22 @@ mod tests {
     }
 
     #[test]
+    fn encode_decode_roundtrip_no_parameters() {
+        let msg = ServerSetup {
+            selected_version: 1,
+            setup_parameters: Vec::new(),
+        };
+
+        let mut buf = BytesMut::new();
+        msg.encode(&mut buf).unwrap();
+
+        let mut decode_buf = buf.clone();
+        let decoded = ServerSetup::decode(&mut decode_buf).unwrap();
+        assert!(decode_buf.is_empty());
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
     fn decode_incomplete() {
         let mut buf = BytesMut::new();
         match ServerSetup::decode(&mut buf) {


### PR DESCRIPTION
## Summary
- improve coverage of `SERVER_SETUP` message
- add test checking encoding/decoding of an empty parameter list

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685e55623ae08329ab90e2e5112f48a6