### PR TITLE
Fix GOAWAY protocol violations

### DIFF
--- a/packages/moqt-transport/src/session.rs
+++ b/packages/moqt-transport/src/session.rs
@@ -198,4 +198,24 @@ mod tests {
             .handle_goaway(&Goaway { new_session_uri: None }, true)
             .unwrap();
     }
+
+    #[test]
+    fn client_accepts_uri_and_sets_state() {
+        let (session, _rx) = Session::new(Arc::new(DummyTransport));
+
+        session
+            .handle_goaway(
+                &Goaway {
+                    new_session_uri: Some("https://example.com".into()),
+                },
+                false,
+            )
+            .unwrap();
+
+        let state = session.state.lock().unwrap();
+        match *state {
+            State::Closing => {}
+            _ => panic!("unexpected state"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- detect GOAWAY URI length overflow as a protocol violation
- test GOAWAY decode error type
- test client handling of GOAWAY with URI

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685e55b62ca883299708f3bb7b632fb4