### PR TITLE
Improve GOAWAY tests

### DIFF
--- a/packages/moqt-transport/src/message/goaway.rs
+++ b/packages/moqt-transport/src/message/goaway.rs
@@ -143,4 +143,15 @@ mod tests {
             e => panic!("unexpected result: {:?}", e),
         }
     }
+
+    #[test]
+    fn decode_incomplete() {
+        let mut buf = BytesMut::new();
+        match Goaway::decode(&mut buf) {
+            Err(crate::error::Error::Io(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof);
+            }
+            r => panic!("unexpected result: {:?}", r),
+        }
+    }
 }

--- a/packages/moqt-transport/src/session.rs
+++ b/packages/moqt-transport/src/session.rs
@@ -192,11 +192,17 @@ mod tests {
     }
 
     #[test]
-    fn server_accepts_no_uri() {
+    fn server_accepts_no_uri_sets_state() {
         let (session, _rx) = Session::new(Arc::new(DummyTransport));
         session
             .handle_goaway(&Goaway { new_session_uri: None }, true)
             .unwrap();
+
+        let state = session.state.lock().unwrap();
+        match *state {
+            State::Closing => {}
+            _ => panic!("unexpected state"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extend GOAWAY message unit tests
- verify session state after server receives GOAWAY

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_685e57253b60832995b307bcbb6cf4c5