### PR TITLE
Ensure REQUESTS_BLOCKED handles oversized IDs

### DIFF
--- a/packages/moqt-transport/src/message/requests_blocked.rs
+++ b/packages/moqt-transport/src/message/requests_blocked.rs
@@ -101,4 +101,18 @@ mod tests {
             r => panic!("unexpected result: {:?}", r),
         }
     }
+
+    #[test]
+    fn encode_fails_on_too_large_id() {
+        // values >= 2^62 cannot be encoded as a varint
+        let msg = RequestsBlocked {
+            maximum_request_id: 1u64 << 62,
+        };
+
+        let mut buf = BytesMut::new();
+        match msg.encode(&mut buf) {
+            Err(crate::error::Error::VarIntRange) => {}
+            r => panic!("unexpected result: {:?}", r),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add missing boundary test for `REQUESTS_BLOCKED`

## Testing
- `cargo test --workspace --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685e58889cdc83298a9b14f99b627127