### PR TITLE
Introduce async Transport interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ bytes = "1.8"
 thiserror = "2.0"
 tokio = "1.45"
 tokio-util = { version = "0.7", features = ["codec"] }
+async-trait = "0.1"

--- a/packages/moqt-transport/Cargo.toml
+++ b/packages/moqt-transport/Cargo.toml
@@ -13,3 +13,4 @@ bytes = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
+async-trait = { workspace = true }

--- a/packages/moqt-transport/src/session.rs
+++ b/packages/moqt-transport/src/session.rs
@@ -71,11 +71,7 @@ impl<T: Transport> Session<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{
-        future::Future,
-        pin::Pin,
-        task::{Context, Poll},
-    };
+    use std::task::{Context, Poll};
     use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
     use crate::transport::{BiStream, BoxError};
 
@@ -127,39 +123,29 @@ mod tests {
     #[derive(Clone)]
     struct DummyTransport;
 
+    #[async_trait::async_trait]
     impl Transport for DummyTransport {
         type Uni = DummyStream;
         type Bi = DummyBi;
 
-        fn open_uni_stream(
-            &mut self,
-        ) -> Pin<Box<dyn Future<Output = Result<Self::Uni, BoxError>> + Send>> {
-            Box::pin(async { unimplemented!() })
+        async fn open_uni_stream(&mut self) -> Result<Self::Uni, BoxError> {
+            unimplemented!()
         }
 
-        fn accept_uni_stream(
-            &mut self,
-        ) -> Pin<Box<dyn Future<Output = Result<Self::Uni, BoxError>> + Send>> {
-            Box::pin(async { unimplemented!() })
+        async fn accept_uni_stream(&mut self) -> Result<Self::Uni, BoxError> {
+            unimplemented!()
         }
 
-        fn open_bi_stream(
-            &mut self,
-        ) -> Pin<Box<dyn Future<Output = Result<Self::Bi, BoxError>> + Send>> {
-            Box::pin(async { unimplemented!() })
+        async fn open_bi_stream(&mut self) -> Result<Self::Bi, BoxError> {
+            unimplemented!()
         }
 
-        fn accept_bi_stream(
-            &mut self,
-        ) -> Pin<Box<dyn Future<Output = Result<Self::Bi, BoxError>> + Send>> {
-            Box::pin(async { unimplemented!() })
+        async fn accept_bi_stream(&mut self) -> Result<Self::Bi, BoxError> {
+            unimplemented!()
         }
 
-        fn send_datagram(
-            &mut self,
-            _data: bytes::Bytes,
-        ) -> Pin<Box<dyn Future<Output = Result<(), BoxError>> + Send>> {
-            Box::pin(async { Ok(()) })
+        async fn send_datagram(&mut self, _data: bytes::Bytes) -> Result<(), BoxError> {
+            Ok(())
         }
     }
 

--- a/packages/moqt-transport/src/transport.rs
+++ b/packages/moqt-transport/src/transport.rs
@@ -1,7 +1,6 @@
-use std::future::Future;
-use std::pin::Pin;
 use tokio::io::{AsyncRead, AsyncWrite};
 use bytes::Bytes;
+use async_trait::async_trait;
 
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
@@ -15,26 +14,16 @@ pub trait BiStream: Send {
     fn split(self) -> (Self::Reader, Self::Writer);
 }
 
+#[async_trait]
 pub trait Transport: Send + Sync {
     type Uni: UniStream;
     type Bi: BiStream;
 
-    fn open_uni_stream(
-        &mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<Self::Uni, BoxError>> + Send>>;
-    fn accept_uni_stream(
-        &mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<Self::Uni, BoxError>> + Send>>;
+    async fn open_uni_stream(&mut self) -> Result<Self::Uni, BoxError>;
+    async fn accept_uni_stream(&mut self) -> Result<Self::Uni, BoxError>;
 
-    fn open_bi_stream(
-        &mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<Self::Bi, BoxError>> + Send>>;
-    fn accept_bi_stream(
-        &mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<Self::Bi, BoxError>> + Send>>;
+    async fn open_bi_stream(&mut self) -> Result<Self::Bi, BoxError>;
+    async fn accept_bi_stream(&mut self) -> Result<Self::Bi, BoxError>;
 
-    fn send_datagram(
-        &mut self,
-        data: Bytes,
-    ) -> Pin<Box<dyn Future<Output = Result<(), BoxError>> + Send>>;
+    async fn send_datagram(&mut self, data: Bytes) -> Result<(), BoxError>;
 }


### PR DESCRIPTION
## Summary
- add `async-trait` to the workspace
- switch `Transport` trait to async methods
- update dummy transport implementation in `Session` tests

## Testing
- `cargo test` *(fails: failed to download async-trait crate)*

------
https://chatgpt.com/codex/tasks/task_e_685ec039ee248329a2bcc43a18fb9a55